### PR TITLE
temporary workaround for tflocal

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack
+    image: localstack/localstack:latest
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
@@ -32,15 +32,10 @@ services:
       - AWS_DEFAULT_REGION=eu-west-1
       - ENV=dev
       - LOCALSTACK_HOSTNAME=localstack
- #      - S3_HOSTNAMEc=localstack
- #      - S3_ENDPOINT=http://localstack:4566
     volumes:
     # https://docs.localstack.cloud/references/init-hooks/
       - ./terraform:/usr/infrastructure
- #    links:
- #      - localstack:s3.localhost.localstack.cloud
- #    extra_hosts:
- #      - s3.localhost.localstack.cloud:127.0.0.1
+
     working_dir: /usr/infrastructure
     entrypoint:
       - '/usr/bin/env'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,16 +1,19 @@
 provider "aws" {
     region = "eu-west-1"
-    access_key = "anaccesskey"
-    secret_key = "asecretkey"
+    access_key = "test"
+    secret_key = "test"
     skip_credentials_validation = true
     skip_requesting_account_id = true 
     skip_metadata_api_check = true
-#   s3_use_path_style = true
+    s3_use_path_style = true
     
     endpoints {
-        s3  = "s3.localhost.localstack.cloud"
+        s3  = "http://localstack:4566"
         sns = "http://localstack:4566"
         sqs = "http://localstack:4566"
+        sts = "http://localstack:4566"
+        iam = "http://localstack:4566"
+        lambda = "http://localstack:4566"
   }
 }
 


### PR DESCRIPTION
Small changes to overcome the `tflocal` local issue https://github.com/localstack/terraform-local/issues/26 where tflocal doesn't automatically set the pat style to `true` because the S3 hostname is not `localhost`. This does not use tflocal, but instead a custom AWS provider with its endpoints pointing to the localstack container.

Feel free to add other services to the list if you're adding services to your Terraform config. 